### PR TITLE
Do not ignore sites/development.services.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 # Ingore files that are only for the current local environment
 /web/sites/*/settings.ramsalt.local.php
 /web/sites/*/services.local.yml
-/web/sites/development.services.yml
 /docker-runtime/
 
 # Ignore Drupal's file directory


### PR DESCRIPTION
Skipping this causes always trouble when developers try to use our default settings.local, I recommend tracking this file.