### PR TITLE
Add ramsalt-module type and installer-path by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,12 +70,13 @@
         ]
     },
     "extra": {
-        "installer-types": ["bower-asset", "npm-asset", "ramsaltmedia-module", "ramsaltmedia-theme"],
+        "installer-types": ["bower-asset", "npm-asset", "ramsaltmedia-module", "ramsalt-module", "ramsaltmedia-theme"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
             "web/libraries/{$name}": ["type:drupal-library", "type:bower-asset", "type:npm-asset"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/modules/ramsaltmedia/{$name}": ["type:ramsaltmedia-module"],
+            "web/modules/ramsalt/{$name}": ["type:ramsalt-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "web/themes/ramsaltmedia/{$name}": ["type:ramsaltmedia-theme"],


### PR DESCRIPTION
We have multiple ramsalt-module right now, would be nice to support it by default in our template 