### PR TITLE
Add ramsalt-module type support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,11 +73,12 @@
         ]
     },
     "extra": {
-        "installer-types": ["bower-asset", "npm-asset", "ramsaltmedia-module", "ramsaltmedia-theme"],
+        "installer-types": ["bower-asset", "npm-asset", "ramsalt-module", "ramsaltmedia-module", "ramsaltmedia-theme"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
             "web/libraries/{$name}": ["type:drupal-library", "type:bower-asset", "type:npm-asset"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
+            "web/modules/ramsalt/{$name}": ["type:ramsalt-module"],
             "web/modules/ramsaltmedia/{$name}": ["type:ramsaltmedia-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],


### PR DESCRIPTION
We only have `ramsaltmedia-module` type support, there are still quite some custom `ramsalt-module` that would be nice to have it predefined