### PR TITLE
Upgrade Drush to 12 due to Drupal 10.2 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/core-composer-scaffold": "^10.0.0",
         "drupal/core-recommended": "^10.0.0",
         "drupal/monolog": "^3.0",
-        "drush/drush": "^11.4.0",
+        "drush/drush": "^12.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "ramsalt/drupal-scaffold": "*",
         "vlucas/phpdotenv": "^5.1",


### PR DESCRIPTION
with Drupal 10.2, the minimum requirement for Drush is 12.4.3