### PR TITLE
Bump php minimum requirement to 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.2']
         drupal-release: ['stable']
         composer-channel: ['stable']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         drupal-release: ['stable']
         composer-channel: ['stable']
         include:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             drupal-release: dev
             composer-channel: stable
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             drupal-release: stable
             composer-channel: snapshot
     steps:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "packagist.org": false
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^10.0.0",


### PR DESCRIPTION
It's a good consideration to start off with php 8.2 with Drupal 10.2 considerations