### PR TITLE
Require PHP >= 8.3 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         drupal-release: ['stable']
         composer-channel: ['stable']
         include:
-          - php-versions: '8.2'
+          - php-versions: '8.3'
             drupal-release: dev
             composer-channel: stable
-          - php-versions: '8.2'
+          - php-versions: '8.3'
             drupal-release: stable
             composer-channel: snapshot
     steps:

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
+        "platform":{
+            "php": "8.3"
+        },
         "discard-changes": true,
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "packagist.org": false
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^10.2.0",


### PR DESCRIPTION
New projects should start with PHP 8.3 now. Force people to start with PHP 8.3 now, even though they might need to change the default DDEV PHP version.