### PR TITLE
Draft: Add support for Drupal recipes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,8 +72,8 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "drupal-recipe": {
-            "unpack-remove-recipe": true,
-            "auto-unpack": true
+            "auto-unpack": true,
+            "unpack-remove-recipe": true
         },
         "drupal-scaffold": {
             "allowed-packages": [

--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,11 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches-file": "composer.patches.json"
+        "patches-file": "composer.patches.json",
+        "drupal-recipe": {
+            "unpack-remove-recipe": true,
+            "auto-unpack": true
+        }
     },
     "scripts": {
         "pre-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,10 @@
     },
     "extra": {
         "composer-exit-on-patch-failure": true,
+        "drupal-recipe": {
+            "unpack-remove-recipe": true,
+            "auto-unpack": true
+        },
         "drupal-scaffold": {
             "allowed-packages": [
                 "ramsalt/drupal-scaffold",
@@ -138,11 +142,7 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches-file": "composer.patches.json",
-        "drupal-recipe": {
-            "unpack-remove-recipe": true,
-            "auto-unpack": true
-        }
+        "patches-file": "composer.patches.json"
     },
     "scripts": {
         "pre-install-cmd": [


### PR DESCRIPTION
The PR adds support for Drupal recipes. I went for the minimal configuration that is placing recipes into `/recipes`, not into a subfolder like `/recipes/contrib`. This is up for discussion and would require the following in Composer `.extra`

```
            "recipes/contrib/{$name}": [
                ["type:drupal-recipe"]
            ]
```

Explanation for the following:
```
        "drupal-recipe": {
            "unpack-remove-recipe": true,
            "auto-unpack": true
        },
```

Only works if https://www.drupal.org/project/distributions_recipes/issues/3355485 is resolved or https://github.com/woredeyonas/Drupal-Recipe-Unpack is used.

So if we vote against both the PR is obsolete.