### PR TITLE
Remove drupal-scaffold file-mapping exclusion for project root .gitignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,6 @@
                 "ramsalt/phpcompatibility-meta"
             ],
             "file-mapping": {
-                "[project-root]/.gitignore": false,
                 "[web-root]/INSTALL.txt": false,
                 "[web-root]/README.txt": false,
                 "[web-root]/sites/development.services.yml": {


### PR DESCRIPTION
In order to allow ramsalt/drupal-scaffold to append ramsalt-specific values to the project root .gitignore, we need to remove the file-mapping exclusion introduced upstream